### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,17 +1,8 @@
-<h2 class="c-project-heading--task">Make the turtle move</h2>
+## Make the turtle move
 
 Start by adding this code to draw the first line.
 
-<div class="c-project-code">
-
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 6-7
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="6-7"
 import turtle
 
 my_turtle = turtle.Turtle()
@@ -19,24 +10,14 @@ my_turtle.speed(4)
 
 # Make a shape
 my_turtle.forward(100)
---- /code ---
-</div>
+```
 
 ## Now run your code
 
-Check that the line the turtle draws. Change the **forward** number to make it longer or shorter. 
-
-<div class="c-project-output">
+Check the line the turtle draws. Change the **forward** number to make it longer or shorter.
 
 ![black turtle line pointing right on a dotted white canvas](images/import-turtle.png)
-</div>
 
-
-<div class="c-project-callout c-project-callout--tip">
-
-### Tip
-
-Edit the **speed** number in the starter code to make the turtle draw faster or slower. 
-
-</div>
-
+> [!TIP]
+>
+> Edit the **speed** number in the starter code to make the turtle draw faster or slower.

--- a/en/step_10.md
+++ b/en/step_10.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Make a snowflake</h2>
+## Make a snowflake
 
 Make a new shape that looks like a snowflake.
 
@@ -8,18 +8,9 @@ Make a new shape that looks like a snowflake.
 
 ## Step 2
 
-Start a **new shape** by drawing at the side of the screen add `penup()` and `pendown()` to your code.
+Start a **new shape** by drawing at the side of the screen. Add `penup()` and `pendown()` to your code.
 
-
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 11-14
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="11-14"
 import turtle
 import random
 
@@ -34,15 +25,10 @@ my_turtle.penup()
 my_turtle.forward(90)
 my_turtle.left(45)
 my_turtle.pendown()
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that the turtle moves to a new starting point before it begins drawing.
 
-<div class="c-project-output">
-
 ![blue turtle arrow on a grey background after moving to a new starting point](images/step10.png)
-
-</div>

--- a/en/step_11.md
+++ b/en/step_11.md
@@ -1,18 +1,10 @@
-<h2 class="c-project-heading--task">Draw a branch</h2>
+## Draw a branch
 
 Write the code to draw one branch of a snowflake.
 
 First define a function called `branch`. Then add code indented inside the `branch` function. This is called at the end with `branch()`.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 10
-line_highlights: 16-28
----
+```python filename="main.py" line_numbers="true" line_number_start="10" line_highlights="16-28"
 # Make a shape
 my_turtle.penup()
 my_turtle.forward(90)
@@ -32,24 +24,14 @@ def branch():
     my_turtle.forward(90)
 
 branch()
---- /code ---
-</div>
+```
 
 ## Now run your code
-Check that the code draws one snowflake branch.
 
-<div class="c-project-output">
+Check that the code draws one snowflake branch.
 
 ![single black snowflake branch on a grey background](images/branch.PNG)
 
-</div>
-
-
-<div class="c-project-callout c-project-callout--debug">
-
-### Debugging
-
-Make sure to check that all your indentation is correct.
-
-</div>
-
+> [!DEBUG]
+>
+> Make sure to check that all your indentation is correct.

--- a/en/step_12.md
+++ b/en/step_12.md
@@ -1,31 +1,18 @@
-<h2 class="c-project-heading--task">Repeat to make the snowflake</h2>
+## Repeat to make the snowflake
 
 Put `branch()` in a loop so that it draws it eight times.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 24
-line_highlights: 28-30
----
+```python filename="main.py" line_numbers="true" line_number_start="24" line_highlights="28-30"
     my_turtle.right(90)
     my_turtle.forward(90)
 
 for i in range(8):
     branch()
     my_turtle.left(45)
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that eight branches join together to make a full snowflake.
 
-<div class="c-project-output">
- 
 ![cyan eight-branch snowflake on a grey background](images/snowflake2.png)
-
-</div>

--- a/en/step_13.md
+++ b/en/step_13.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Challenge</h2>
+## Challenge
 
 Make every snowflake different.
 
@@ -6,19 +6,10 @@ Make every snowflake different.
 
 Add random colours to each branch so that each is a new colour.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: false
-line_number_start: 
-line_highlights: 
----
+```python filename="main.py"
 my_turtle.color(random.choice(colours))
 
---- /code ---
-</div>
+```
 
 ## Step 2
 

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,16 +1,8 @@
-<h2 class="c-project-heading--task">Turn your turtle</h2>
+## Turn your turtle
 
 Add code that **turns** `my_turtle` to draw your shape.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 8
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="8"
 import turtle
 
 my_turtle = turtle.Turtle()
@@ -20,23 +12,14 @@ my_turtle.speed(4)
 my_turtle.forward(100)
 my_turtle.right(90)
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that the turtle draws a line and then turns. Experiment with `right` and `left` to change the direction. Change the number to turn the turtle more or less.
 
-<div class="c-project-output">
-
 ![black line with the turtle arrow turned downward](images/step2.png)
 
-</div>
-
-<div class="c-project-callout c-project-callout--tip">
-
-### Tip
-
-The value `90` inside the brackets is in degrees. So this line tells your turtle to turn right by 90 degrees.
-
-</div>
+> [!TIP]
+>
+> The value `90` inside the brackets is in degrees. So this line tells your turtle to turn right by 90 degrees.

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,16 +1,8 @@
-<h2 class="c-project-heading--task">Make a square</h2>
+## Make a square
 
-Add the following code to to make a square
+Add the following code to make a square.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 3
-line_highlights: 9-13
----
+```python filename="main.py" line_numbers="true" line_number_start="3" line_highlights="9-13"
 my_turtle = turtle.Turtle()
 my_turtle.speed(4)
 
@@ -22,15 +14,10 @@ my_turtle.right(90)
 my_turtle.forward(100)
 my_turtle.right(90)
 my_turtle.forward(100)
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that the turtle draws a square.
 
-<div class="c-project-output">
-
 ![black square outline with the turtle arrow pointing up at the top-left corner](images/step3.png)
-
-</div>

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,50 +1,31 @@
-<h2 class="c-project-heading--task">Use a loop</h2>
+## Use a loop
 
 Instead of typing out many lines of code, it's easier to use a loop.
 
 ## Step 1
 
-**Delete the code** you added to make a square. 
+**Delete the code** you added to make a square.
 
 ## Step 2
 
 Put the first two lines in a loop with `range(4)`.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 3
-line_highlights: 7-9
----
+```python filename="main.py" line_numbers="true" line_number_start="3" line_highlights="7-9"
 my_turtle = turtle.Turtle()
 my_turtle.speed(4)
 
 # Make a shape
-for i in :
+for i in range(4):
     my_turtle.forward(100)
     my_turtle.right(90)
---- /code ---  
-</div>
+```
 
 ## Now run your code
 
 Check that the loop draws a square.
 
-<div class="c-project-output">
-
 ![black square outline with the turtle arrow at the top-left corner](images/turtle-loop.png)
 
-</div>
-
-<div class="c-project-callout c-project-callout--debug">
-
-### Debugging
-
-Make sure your code is indented like the example.
-
-</div>
-
-
+> [!DEBUG]
+>
+> Make sure your code is indented like the example.

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,16 +1,8 @@
-<h2 class="c-project-heading--task">Create different shapes</h2>
+## Create different shapes
 
 Replace the code for your square with the following, and experiment to make different shapes.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 7-11
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="7-11"
 import turtle
 
 my_turtle = turtle.Turtle()
@@ -22,16 +14,10 @@ for i in range(2):
     my_turtle.right(60)
     my_turtle.forward(100)
     my_turtle.right(120)
---- /code --- 
-</div>
+```
 
 ## Now run your code
 
 Check that the turtle draws a parallelogram.
 
-<div class="c-project-output">
-
 ![black parallelogram outline with the turtle arrow at the upper-left corner](images/parallelogram.png)
-
-</div>
-

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,18 +1,10 @@
-<h2 class="c-project-heading--task">Loops in loops</h2>
+## Loops in loops
 
 You can put loops inside of other loops to repeat and overlap shapes.
 
-Add an outer loop in the line above `for i in range(2):`. 
+Add an outer loop in the line above `for i in range(2):`.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 3
-line_highlights: 7-13
----
+```python filename="main.py" line_numbers="true" line_number_start="3" line_highlights="7-13"
 my_turtle = turtle.Turtle()
 my_turtle.speed(4)
 
@@ -24,22 +16,14 @@ for i in range(10):
         my_turtle.forward(100)
         my_turtle.right(120)
     my_turtle.right(36)
---- /code --- 
-</div>
+```
 
 ## Now run your code
 
 Check that the repeated shape makes a snowflake pattern.
 
-<div class="c-project-output">
-
 ![overlapping black parallelogram outlines arranged as a snowflake](images/snowflake1.png)
-</div>
 
-<div class="c-project-callout c-project-callout--tip">
-
-### Tip
-
-Make sure to indent the code below a loop.
-
-</div>
+> [!TIP]
+>
+> Make sure to indent the code below a loop.

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,20 +1,12 @@
-<h2 class="c-project-heading--task">Changing colours</h2>
+## Changing colours
 
 So far the turtle has been drawing black lines on a white background.
 
 ## Step 1
 
-Set the colour of the turtle in the code. 
+Set the colour of the turtle in the code.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 5
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="5"
 import turtle
 
 my_turtle = turtle.Turtle()
@@ -23,37 +15,25 @@ my_turtle.color('cyan')
 
 # Make a shape
 for i in range(10):
---- /code ---
-</div>
+```
 
 ## Step 2
 
-Experiment with other colours. 
+Experiment with other colours.
 
-<div class="c-project-callout c-project-callout--tip">
-
-### Tip
-
-`cyan` is used in the example above, but you can use other colours, including any from this list:
-
-- 'orange'
-- 'yellow'
-- 'purple'
-- 'blue'
-
-Have a look at [this website](https://wiki.tcl.tk/37701) for a complete list.
-
-</div>
+> [!TIP]
+>
+> `cyan` is used in the example above, but you can use other colours, including any from this list:
+>
+> - 'orange'
+> - 'yellow'
+> - 'purple'
+> - 'blue'
+>
+> Have a look at [this website](https://wiki.tcl.tk/37701) for a complete list.
 
 ## Now run your code
 
 Check that the snowflake is drawn in the colour you chose.
 
-<div class="c-project-output">
-
 ![blue snowflake outline on a dotted white canvas](images/step7.png)
-
-</div>
-
-
-

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -1,16 +1,8 @@
-<h2 class="c-project-heading--task">Set the background</h2>
+## Set the background
 
-Change the colour of the background by adding the code below. You can experiment with other colours. 
+Change the colour of the background by adding the code below. You can experiment with other colours.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 6
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="6"
 import turtle
 
 my_turtle = turtle.Turtle()
@@ -20,17 +12,12 @@ turtle.Screen().bgcolor('grey')
 
 # Make a shape
 for i in range(10):
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that the snowflake is drawn on a new background colour.
 
-
-<div class="c-project-output">
-Here is an example of the snowflake on a grey background
+Here is an example of the snowflake on a grey background.
 
 ![cyan snowflake outline on a grey background](images/step8.png)
-
-</div>

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -1,61 +1,35 @@
-<h2 class="c-project-heading--task">Add a random colour</h2>
+## Add a random colour
 
 Add the code so that every time you run your code, you will get a slightly different snowflake.
 
 ## Step 1
 
-First import the `random` library. 
+First import the `random` library.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 1
-line_highlights: 2
----
+```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="2"
 import turtle
 import random
 
 my_turtle = turtle.Turtle()
---- /code ---
-</div>
+```
 
 ## Step 2
 
 Then create a list called `colours` to store colours to select from.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 7
-line_highlights: 8
----
+```python filename="main.py" line_numbers="true" line_number_start="7" line_highlights="8"
 turtle.Screen().bgcolor('grey')
 colours = ['cyan', 'purple', 'white', 'blue']
 
 # Make a shape
 for i in range(10):
---- /code ---
-</div>
+```
 
 ## Step 3
 
 At the end of the loop, choose a random colour from the list.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-filename: main.py
-line_numbers: true
-line_number_start: 10
-line_highlights: 18
----
+```python filename="main.py" line_numbers="true" line_number_start="10" line_highlights="18"
 # Make a shape
 for i in range(10):
     for i in range(2):
@@ -65,14 +39,10 @@ for i in range(10):
         my_turtle.right(120)
     my_turtle.right(36)
     my_turtle.color(random.choice(colours))
---- /code ---
-</div>
+```
 
 ## Now run your code
 
 Check that different parts of the snowflake use colours from your list.
 
-<div class="c-project-output">
-
 ![snowflake outline in cyan, purple, and blue on a grey background](images/colour-list.png)
-</div>


### PR DESCRIPTION
Converts all step files to the new Raspberry Flavoured Markdown spec.

- Task headings → \`##\` level-2 headings
- Code blocks → fenced blocks with inline attributes (unset/false attributes omitted)
- Tip/debug callouts → \`> [!TIP]\` / \`> [!DEBUG]\` blocks
- Dropped \`c-project-output\` wrappers, leaving bare images
- Kept \`## Step N\` sub-headings for multi-task steps
- Fixed \`step_4\` code: \`for i in :\` → \`for i in range(4):\`
- SPAG: step_1 stray "that", step_3 doubled "to" + full stop, step_8 full stop, step_10 run-on sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)