### PR TITLE
Use > [!CHALLENGE] blocks for the challenge step

### DIFF
--- a/en/step_13.md
+++ b/en/step_13.md
@@ -2,23 +2,15 @@
 
 Make every snowflake different.
 
-## Step 1
+> [!CHALLENGE]
+> Add random colours to each branch so that each is a new colour.
+>
+> ```python filename="main.py"
+> my_turtle.color(random.choice(colours))
+> ```
 
-Add random colours to each branch so that each is a new colour.
+> [!CHALLENGE]
+> Create a snowflake function and then repeat it all over the screen to create a snowflake landscape.
 
-```python filename="main.py"
-my_turtle.color(random.choice(colours))
-
-```
-
-## Step 2
-
-Create a snowflake function and then repeat it all over the screen to create a snowflake landscape.
-
-## Step 3
-
-Draw snowflakes of different colours and different sizes, like those in Carrie Anne's video [Make snowflakes with code](https://www.youtube.com/watch?v=DHmeX7YTHBY).
-
-## Now run your code
-
-Run your code and check that the branches can appear in different colours and that any extra snowflakes you add show on the screen.
+> [!CHALLENGE]
+> Draw snowflakes of different colours and different sizes, like those in Carrie Anne's video [Make snowflakes with code](https://www.youtube.com/watch?v=DHmeX7YTHBY).


### PR DESCRIPTION
Follow-up to the RPF conversion: restructure the challenge step (step_13) to use one `> [!CHALLENGE]` block per suggestion.

- Split into separate `> [!CHALLENGE]` blocks (one per challenge idea)
- Dropped generic `## Step N` headings
- Code fence kept inside the first challenge block
- Removed the trailing `## Now run your code` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)